### PR TITLE
Moved some scructs into their own packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ go build ./
 2) Register the chaincode with a peer
 
 ```
-CORE_CHAINCODE_ID_NAME=insurance CORE_PEER_ADDRESS=0.0.0.0:7051 ./insurance_code
+CORE_CHAINCODE_ID_NAME=insurance CORE_PEER_ADDRESS=0.0.0.0:7051 ./insurance_main
 ```
 
 3) Send a REST request to enroll a user

--- a/chaincode/src/claim/claim.go
+++ b/chaincode/src/claim/claim.go
@@ -1,0 +1,112 @@
+package claim
+
+//==============================================================================================================================
+//	Claim - Defines the structure for a Claim object.
+//==============================================================================================================================
+type Claim struct {
+	Id		string				`json:"id"`
+	Type		string			`json:"type"`
+	Details		ClaimDetails	`json:"details"`
+	Relations 	ClaimRelations	`json:"relations"`
+}
+
+//==============================================================================================================================
+//	ClaimDetails - Defines the structure for a ClaimDetails object.
+//==============================================================================================================================
+type ClaimDetails struct {
+	Status		string							`json:"status"`
+	Description	string							`json:"description"`
+	Incident	ClaimDetailsIncident			`json:"incident"`
+	Repair		ClaimDetailsClaimGarageReport	`json:"repair"`
+	Settlement	ClaimDetailsSettlement			`json:"settlement"`
+}
+
+//==============================================================================================================================
+//	ClaimDetailsIncident - Defines the structure for a ClaimDetailsIncident object.
+//==============================================================================================================================
+type ClaimDetailsIncident struct {
+	Date	string	`json:"date"`
+	Type	string	`json:"type"`
+}
+
+//==============================================================================================================================
+//	ClaimDetailsClaimGarageReport - Defines the structure for a ClaimDetailsClaimGarageReport object.
+//==============================================================================================================================
+type ClaimDetailsClaimGarageReport struct {
+	Garage		string	`json:"garage"`
+	Estimate	int		`json:"estimate"`
+	Actual		int		`json:"actual"`
+	WriteOff	bool	`json:"writeOff"`
+	Notes		string	`json:"notes"`
+}
+
+//==============================================================================================================================
+//	ClaimDetailsSettlement - Defines the structure for a ClaimDetailsSettlement object.
+//==============================================================================================================================
+type ClaimDetailsSettlement struct {
+	Decision	string							`json:"decision"`
+	Dispute		bool							`json:"dispute"`
+	TotalLoss	ClaimDetailsSettlementTotalLoss	`json:"totalLoss"`
+	Payments	[]ClaimDetailsSettlementPayment	`json:"payments"`
+}
+
+//==============================================================================================================================
+//	ClaimDetailsSettlementTotalLoss - Defines the structure for a ClaimDetailsSettlementTotalLoss object.
+//==============================================================================================================================
+type ClaimDetailsSettlementTotalLoss struct {
+	CarValueEstimate	int	`json:"carValueEstimate"`
+	CustomerAgreedValue	int	`json:"customerAgreedValue"`
+}
+
+//==============================================================================================================================
+//	ClaimDetailsSettlementPayment - Defines the structure for a ClaimDetailsSettlementPayment object.
+//==============================================================================================================================
+type ClaimDetailsSettlementPayment struct {
+	RecipientType	string	`json:"recipientType"`
+	Recipient	string		`json:"recipient"`
+	Amount		int			`json:"amount"`
+	Status		string		`json:"status"`
+}
+
+//==============================================================================================================================
+//	ClaimRelations - Defines the structure for a ClaimRelations object.
+//==============================================================================================================================
+type ClaimRelations struct {
+	RelatedPolicy	string	`json:"relatedPolicy"`
+}
+
+//==============================================================================================================================
+//	 Claim Status types - TODO Flesh these out. TODO Following IBM sample, but should/could these be enums?
+//==============================================================================================================================
+const   STATE_AWAITING_POLICE_REPORT                = "awaiting_police_report"
+const   STATE_AWAITING_GARAGE_REPORT                = "awaiting_garage_report"
+const   STATE_AWAITING_GARAGE_WORK_CONFIRMATION     = "awaiting_garage_work"
+const   STATE_SETTLED  			                    = "settled"
+const	STATUS_OPEN									= "open"
+const	STATUS_CLOSED								= "closed"
+
+//==============================================================================================================================
+//	 Claim Type types - TODO Flesh these out. TODO Following IBM sample, but should these be enums?
+//==============================================================================================================================
+const   SINGLE_PARTY                =  "single_party"
+const   MULTIPLE_PARTIES  			=  "multiple_parties"
+
+//=================================================================================================================================
+//	 newClaim	-	Constructs a new claim
+//=================================================================================================================================
+func New(id string, relatedPolicy string, description string, incidentDate string, incidentType string) (Claim) {
+
+	var claim Claim
+
+	claim.Id = id
+	claim.Type = "claim"
+
+	claim.Relations.RelatedPolicy = relatedPolicy
+	claim.Details.Description = description
+	claim.Details.Incident.Date = incidentDate
+	claim.Details.Incident.Type = incidentType
+
+	claim.Details.Status = STATUS_OPEN
+
+	return claim
+}

--- a/chaincode/src/insurance_main/insurance.go
+++ b/chaincode/src/insurance_main/insurance.go
@@ -135,7 +135,7 @@ func (t *InsuranceChaincode) addPolicy(stub shim.ChaincodeStubInterface, caller 
 	}
 
 	excess, _ := strconv.Atoi(args[2])
-	policy := t.newPolicy(t.getNextPolicyId(stub), caller, args[0], args[1], excess, args[3])
+	policy := policy.New(t.getNextPolicyId(stub), caller, args[0], args[1], excess, args[3])
 
 	bytes, err := json.Marshal(policy)
 
@@ -146,25 +146,6 @@ func (t *InsuranceChaincode) addPolicy(stub shim.ChaincodeStubInterface, caller 
 	if err != nil { fmt.Printf("addPolicy: Error storing policy record: %s", err); return nil, errors.New("Error storing policy record") }
 
 	return nil, nil
-}
-
-//=================================================================================================================================
-//	 newPolicy	-	Constructs a new policy
-//=================================================================================================================================
-func (t *InsuranceChaincode) newPolicy(id string, owner string, startDate string, endDate string, excess int, vehicleReg string) (policy.Policy) {
-	var policy policy.Policy
-
-	policy.Id = id
-	policy.Type = "policy"
-
-	policy.Details.StartDate = startDate
-	policy.Details.EndDate = endDate
-	policy.Details.Excess = excess
-
-	policy.Relations.Owner = owner
-	policy.Relations.Vehicle = vehicleReg
-
-	return policy
 }
 
 //=================================================================================================================================

--- a/chaincode/src/insurance_main/insurance.go
+++ b/chaincode/src/insurance_main/insurance.go
@@ -8,15 +8,11 @@ import (
 	"encoding/json"
 	"policy"
 	"claim"
-	"github.com/hyperledger/fabric/membersrvc/ca"
 	"init_data"
 	"user"
 	"vehicle"
 	"approved_garages"
 )
-
-//Used to store all current approved garages
-var allApprovedGarages approved_garages.ApprovedGarages
 
 // InsuranceChaincode example simple Chaincode implementation
 type InsuranceChaincode struct {}
@@ -48,6 +44,9 @@ const	CURRENT_VEHICLE_ID_KEY	= "currentVehicleId"
 const	CURRENT_USER_ID_KEY	= "currentUserId"
 const   CURRENT_CLAIM_ID_KEY	= "currentClaimId"
 
+//Used to store all current approved garages
+const	APPROVED_GARAGES_KEY	= "approvedGarages"
+
 //==============================================================================================================================
 //	 Prefixes for the different domain object type ids
 //==============================================================================================================================
@@ -77,7 +76,7 @@ func (t *InsuranceChaincode) Init(stub shim.ChaincodeStubInterface, function str
 
 	t.initSetup(stub)
 
-	return nil, nil, nil, nil
+	return nil, nil
 }
 
 // Invoke is the entry point to invoke a chaincode function
@@ -204,7 +203,7 @@ func (t *InsuranceChaincode) addUser(stub shim.ChaincodeStubInterface, caller st
 //=================================================================================================================================
 func (t *InsuranceChaincode) appendApprovedGarages(stub shim.ChaincodeStubInterface, approvedGarages []string) ([]byte, error){
 
-	garages, err := stub.GetState(allApprovedGarages)
+	garages, err := stub.GetState(APPROVED_GARAGES_KEY)
 
 	if err != nil {
 		return nil, errors.New("Failed to get allApprovedGarages")
@@ -217,7 +216,7 @@ func (t *InsuranceChaincode) appendApprovedGarages(stub shim.ChaincodeStubInterf
 
 	newGarages.Garages = approvedGarages
 
-	approvedGaragesList = append(approvedGaragesList, newGarages)
+	approvedGaragesList.Garages = append(approvedGaragesList.Garages, newGarages.Garages...)
 
 	bytes, err := json.Marshal(approvedGaragesList)
 
@@ -225,7 +224,7 @@ func (t *InsuranceChaincode) appendApprovedGarages(stub shim.ChaincodeStubInterf
 		fmt.Printf("addApprovedGarages: Error converting garages: %s", err); return nil, errors.New("Error converting garages")
 	}
 
-	err = stub.PutState(allApprovedGarages, bytes)
+	err = stub.PutState(APPROVED_GARAGES_KEY, bytes)
 
 	if err != nil {
 		fmt.Printf("addApprovedGarages: Error adding approved garages: %s", err); return nil, errors.New("Error adding approved garages")

--- a/chaincode/src/policy/policy.go
+++ b/chaincode/src/policy/policy.go
@@ -1,0 +1,52 @@
+package policy
+
+//==============================================================================================================================
+//	Policy - Defines the structure for a policy object. JSON on right tells it what JSON fields to map to
+//			  that element when reading a JSON object into the struct e.g. JSON make -> Struct Make.
+//==============================================================================================================================
+type Policy struct {
+	Id		string					`json:"id"`
+	Type		string				`json:"type"`
+	Details		PolicyDetails		`json:"details"`
+	Relations 	PolicyRelations		`json:"relations"`
+}
+
+//==============================================================================================================================
+//	PolicyDetails - Defines the structure for the PolicyDetails object.
+//==============================================================================================================================
+
+
+type PolicyDetails struct {
+	StartDate	string			`json:"startDate"`
+	EndDate		string			`json:"endDate"`
+	Excess		int				`json:"excess"`
+}
+
+//==============================================================================================================================
+//	PolicyRelations - Defines the structure for a PolicyRelations object.
+//==============================================================================================================================
+type PolicyRelations struct {
+	Owner		string			`json:"owner"`
+	Vehicle		string			`json:"vehicle"`
+	Claims		[]string		`json:"claims"`
+
+}
+
+//=================================================================================================================================
+//	 newPolicy	-	Constructs a new policy
+//=================================================================================================================================
+func New(id string, owner string, startDate string, endDate string, excess int, vehicleReg string) (Policy) {
+	var policy Policy
+
+	policy.Id = id
+	policy.Type = "policy"
+
+	policy.Details.StartDate = startDate
+	policy.Details.EndDate = endDate
+	policy.Details.Excess = excess
+
+	policy.Relations.Owner = owner
+	policy.Relations.Vehicle = vehicleReg
+
+	return policy
+}


### PR DESCRIPTION
I feel like the insurance.go file was getting quite messy with all the structs in a single file so I've split the policy and claim structs into seperate files/packages, along with the factory functions that create a new policy/claim.  I'm not sure if this is the 'Go Way' or not, but I think it makes things a bit tidier. This could be the wrong approach though, as I'm no Go expert...happy for this to be rejected if its weird for Go.