### PR TITLE
Refactor/chaincode splitting

### DIFF
--- a/chaincode/src/insurance_crud/insuranceCrud.go
+++ b/chaincode/src/insurance_crud/insuranceCrud.go
@@ -4,11 +4,19 @@ import (
 	"fmt"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"errors"
+	"encoding/json"
 )
 
 
 // InsuranceChaincode
 type InsuranceCrudChaincode struct {}
+
+//Holds a list of keys added to state
+type KeyHolder struct {
+	Keys 	[]string 	`json:"keys"`
+}
+
+const KEYHOLDER_KEY = "KEYHOLDER_KEY"
 
 func main() {
 	err := shim.Start(new(InsuranceCrudChaincode))
@@ -19,13 +27,31 @@ func main() {
 
 func (t *InsuranceCrudChaincode) Init(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 
-	return nil, nil
+	//Only applied in dev mode as the chaincode will be deployed with a fresh chaincodeId in prod mode
+	t.wipeData(stub)
+
+	//Add new key holder
+	var keyHolder KeyHolder
+	keyHolder.Keys = []string{}
+	bytes, err := json.Marshal(keyHolder)
+
+	if (err != nil) {fmt.Printf("\nError when creating empty key holder: %s", err); return nil, err}
+
+	err = stub.PutState(KEYHOLDER_KEY, bytes)
+
+	return nil, err
 }
 
 // Invoke is the entry point to invoke a chaincode function
 func (t *InsuranceCrudChaincode) Invoke(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 	fmt.Println("invoke is running " + function)
-	stub.GetCallerCertificate()
+
+	//Check that this chaincode was invoked internally by another chaincode contract
+	if !t.isTxIdValid(stub, args) {
+		fmt.Println("TxId does not match, aborting")
+		return nil, errors.New("TxId does not match")
+	}
+
 	// Handle different functions
 	if function == "init" {
 		return t.Init(stub, "init", args)
@@ -41,6 +67,12 @@ func (t *InsuranceCrudChaincode) Invoke(stub shim.ChaincodeStubInterface, functi
 func (t *InsuranceCrudChaincode) Query(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 	fmt.Println("query is running " + function)
 
+	//Check that this chaincode was invoked internally by another chaincode contract
+	if !t.isTxIdValid(stub, args) {
+		fmt.Println("TxId does not match, aborting")
+		return nil, errors.New("TxId does not match")
+	}
+
 	if function == "retrieve" {
 		return t.retrieve(stub, args)
 	}
@@ -52,28 +84,95 @@ func (t *InsuranceCrudChaincode) Query(stub shim.ChaincodeStubInterface, functio
 
 //=================================================================================================================================
 //	 Saves a value into state, with the specified key
-//		args - key, value
+//		args - txId, key, value
 //=================================================================================================================================
 func (t *InsuranceCrudChaincode) save(stub shim.ChaincodeStubInterface, args []string) ([]byte, error){
 
-	if len(args) != 2 {
-		return nil, errors.New("Incorrect number of arguments. Expecting 2 (Key, Value)")
+	if len(args) != 3 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 3 (TxId, Key, Value)")
 	}
 
-	err := stub.PutState(args[0], []byte(args[1]))
+	err := stub.PutState(args[1], []byte(args[2]))
 
+	if (err == nil) {fmt.Println("SAVE (KEY " + args[1] + "): " + string(args[2]))}
+
+	t.addKey(stub, args[1])
 	return nil, err
 }
 
 //=================================================================================================================================
 //	 Retrieves a value from state, with the specified key
-//		args - key
+//		args - txId, key
 //=================================================================================================================================
 func (t *InsuranceCrudChaincode) retrieve(stub shim.ChaincodeStubInterface, args []string) ([]byte, error){
 
-	if len(args) != 1 {
-		return nil, errors.New("Incorrect number of arguments. Expecting 1 (Key)")
+	if len(args) != 2 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 2 (TxId, Key)")
 	}
 
-	return stub.GetState(args[0])
+	bytes, err := stub.GetState(args[1])
+
+	if (err == nil) {fmt.Println("RETRIEVE (KEY " + args[1] + "): " + string(bytes))}
+
+	return bytes, err;
+}
+
+//=================================================================================================================================
+//	 This chaincode should not be invoked externally.  To confirm that the invoke/query was performed from
+//	 another chaincode, the txId must be passed as the first argument, and if this does not match the txId
+//   returned from the stub, we should not allow the request to proceed.
+//   (Only another chaincode can know the txId before sending the request)
+//=================================================================================================================================
+func (t *InsuranceCrudChaincode) isTxIdValid(stub shim.ChaincodeStubInterface, args []string) (bool){
+
+	if len(args) == 0 {
+		return false
+	}
+
+	return stub.GetTxID() == args[0]
+}
+
+//Wipes all data
+func (t *InsuranceCrudChaincode) wipeData(stub shim.ChaincodeStubInterface){
+
+	fmt.Println("WIPING STATE")
+
+	keyHolder, err := t.getKeyHolder(stub)
+
+	if (err != nil) {fmt.Printf("\nError when wiping state: %s", err)}
+	if err == nil {
+		for _,key := range keyHolder.Keys {
+			stub.DelState(key)
+			fmt.Println("Deleted key: " + key)
+		}
+	}
+}
+
+func (t *InsuranceCrudChaincode) addKey(stub shim.ChaincodeStubInterface, key string) (error) {
+	bytes, _ := stub.GetState(KEYHOLDER_KEY)
+
+	var keyHolder KeyHolder
+
+	err := json.Unmarshal(bytes, keyHolder);
+
+	if err == nil {
+		keyHolder.Keys = append(keyHolder.Keys, key)
+
+		bytes, err = json.Marshal(keyHolder)
+		stub.PutState(KEYHOLDER_KEY, bytes)
+	}
+
+	return err
+}
+
+func (t *InsuranceCrudChaincode) getKeyHolder(stub shim.ChaincodeStubInterface) (KeyHolder, error) {
+	bytes, _ := stub.GetState(KEYHOLDER_KEY)
+
+	var keyHolder KeyHolder
+
+	err := json.Unmarshal(bytes, &keyHolder);
+
+	fmt.Println(string(bytes))
+
+	return keyHolder, err
 }

--- a/chaincode/src/insurance_crud/insuranceCrud.go
+++ b/chaincode/src/insurance_crud/insuranceCrud.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"errors"
+)
+
+
+// InsuranceChaincode
+type InsuranceCrudChaincode struct {}
+
+func main() {
+	err := shim.Start(new(InsuranceCrudChaincode))
+	if err != nil {
+		fmt.Printf("Error starting Insurance CRUD chaincode: %s", err)
+	}
+}
+
+func (t *InsuranceCrudChaincode) Init(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
+
+	return nil, nil
+}
+
+// Invoke is the entry point to invoke a chaincode function
+func (t *InsuranceCrudChaincode) Invoke(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
+	fmt.Println("invoke is running " + function)
+	stub.GetCallerCertificate()
+	// Handle different functions
+	if function == "init" {
+		return t.Init(stub, "init", args)
+	} else if function == "save" {
+		return t.save(stub, args)
+	}
+	fmt.Println("invoke did not find func: " + function)
+
+	return nil, errors.New("Received unknown function invocation: " + function)
+}
+
+// Query is our entry point for queries
+func (t *InsuranceCrudChaincode) Query(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
+	fmt.Println("query is running " + function)
+
+	if function == "retrieve" {
+		return t.retrieve(stub, args)
+	}
+
+	fmt.Println("query did not find func: " + function)
+
+	return nil, errors.New("Received unknown function query: " + function)
+}
+
+//=================================================================================================================================
+//	 Saves a value into state, with the specified key
+//		args - key, value
+//=================================================================================================================================
+func (t *InsuranceCrudChaincode) save(stub shim.ChaincodeStubInterface, args []string) ([]byte, error){
+
+	if len(args) != 2 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 2 (Key, Value)")
+	}
+
+	err := stub.PutState(args[0], []byte(args[1]))
+
+	return nil, err
+}
+
+//=================================================================================================================================
+//	 Retrieves a value from state, with the specified key
+//		args - key
+//=================================================================================================================================
+func (t *InsuranceCrudChaincode) retrieve(stub shim.ChaincodeStubInterface, args []string) ([]byte, error){
+
+	if len(args) != 1 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 1 (Key)")
+	}
+
+	return stub.GetState(args[0])
+}

--- a/chaincode/src/insurance_crud/insuranceCrud.go
+++ b/chaincode/src/insurance_crud/insuranceCrud.go
@@ -27,7 +27,7 @@ func main() {
 
 func (t *InsuranceCrudChaincode) Init(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 
-	//Only applied in dev mode as the chaincode will be deployed with a fresh chaincodeId in prod mode
+	//Only applies in dev mode as the chaincode will be deployed with a fresh chaincodeId in prod mode
 	t.wipeData(stub)
 
 	//Add new key holder
@@ -96,7 +96,7 @@ func (t *InsuranceCrudChaincode) save(stub shim.ChaincodeStubInterface, args []s
 
 	if (err == nil) {fmt.Println("SAVE (KEY " + args[1] + "): " + string(args[2]))}
 
-	t.addKey(stub, args[1])
+	err = t.addKey(stub, args[1])
 	return nil, err
 }
 
@@ -151,9 +151,7 @@ func (t *InsuranceCrudChaincode) wipeData(stub shim.ChaincodeStubInterface){
 func (t *InsuranceCrudChaincode) addKey(stub shim.ChaincodeStubInterface, key string) (error) {
 	bytes, _ := stub.GetState(KEYHOLDER_KEY)
 
-	var keyHolder KeyHolder
-
-	err := json.Unmarshal(bytes, keyHolder);
+	keyHolder, err := t.getKeyHolder(stub)
 
 	if err == nil {
 		keyHolder.Keys = append(keyHolder.Keys, key)
@@ -171,8 +169,6 @@ func (t *InsuranceCrudChaincode) getKeyHolder(stub shim.ChaincodeStubInterface) 
 	var keyHolder KeyHolder
 
 	err := json.Unmarshal(bytes, &keyHolder);
-
-	fmt.Println(string(bytes))
 
 	return keyHolder, err
 }

--- a/chaincode/src/insurance_main/dao.go
+++ b/chaincode/src/insurance_main/dao.go
@@ -120,6 +120,24 @@ func RetrieveAllClaims(stub shim.ChaincodeStubInterface) ([]Claim){
 	return claims
 }
 
+func SaveVehicle(stub shim.ChaincodeStubInterface, vehicle Vehicle) (Vehicle, error) {
+	if vehicle.Id == "" {
+		vehicle.Id = vehicle.Details.Registration
+	}
+
+	err := saveObject(stub, vehicle.Id, vehicle)
+
+	return vehicle, err
+}
+
+func RetrieveVehicle(stub shim.ChaincodeStubInterface, id string) (Vehicle, error){
+	var vehicle Vehicle
+
+	err := retrieveObject(stub, id, vehicle)
+
+	return vehicle, err
+}
+
 func retrieve(stub shim.ChaincodeStubInterface, id string) ([]byte, error) {
 	return query(stub, getCrudChaincodeId(stub), RETRIEVE_FUNCTION, []string{id})
 }

--- a/chaincode/src/insurance_main/dao.go
+++ b/chaincode/src/insurance_main/dao.go
@@ -56,7 +56,7 @@ func SavePolicy(stub shim.ChaincodeStubInterface, policy Policy) (Policy, error)
 func RetrievePolicy(stub shim.ChaincodeStubInterface, id string) (Policy, error){
 	var policy Policy
 
-	err := retrieveObject(stub, id, policy)
+	err := retrieveObject(stub, id, &policy)
 
 	return policy, err
 }
@@ -95,7 +95,7 @@ func SaveClaim(stub shim.ChaincodeStubInterface, claim Claim) (Claim, error) {
 func RetrieveClaim(stub shim.ChaincodeStubInterface, id string) (Claim, error){
 	var claim Claim
 
-	err := retrieveObject(stub, id, claim)
+	err := retrieveObject(stub, id, &claim)
 
 	return claim, err
 }
@@ -132,7 +132,7 @@ func SaveVehicle(stub shim.ChaincodeStubInterface, vehicle Vehicle) (Vehicle, er
 func RetrieveVehicle(stub shim.ChaincodeStubInterface, id string) (Vehicle, error){
 	var vehicle Vehicle
 
-	err := retrieveObject(stub, id, vehicle)
+	err := retrieveObject(stub, id, &vehicle)
 
 	return vehicle, err
 }
@@ -152,7 +152,7 @@ func SaveUser(stub shim.ChaincodeStubInterface, user User) (User, error) {
 func RetrieveUser(stub shim.ChaincodeStubInterface, id string) (User, error){
 	var user User
 
-	err := retrieveObject(stub, id, user)
+	err := retrieveObject(stub, id, &user)
 
 	return user, err
 }
@@ -166,7 +166,7 @@ func SaveApprovedGarages(stub shim.ChaincodeStubInterface, approvedGarages Appro
 func RetrieveApprovedGarages(stub shim.ChaincodeStubInterface) (ApprovedGarages, error){
 	var approvedGarages ApprovedGarages
 
-	err := retrieveObject(stub, APPROVED_GARAGES_KEY, approvedGarages)
+	err := retrieveObject(stub, APPROVED_GARAGES_KEY, &approvedGarages)
 
 	return approvedGarages, err
 }
@@ -192,11 +192,11 @@ func retrieve(stub shim.ChaincodeStubInterface, id string) ([]byte, error) {
 func retrieveObject(stub shim.ChaincodeStubInterface, id string, toStoreObject interface{}) (error){
 	bytes, err := retrieve(stub, id)
 
-	if err != nil {	fmt.Printf("RetrievePolicy: Cannot retrieve object with id: " + id + " : %s", err); return err}
+	if err != nil {	fmt.Printf("RetrieveObject: Cannot retrieve object with id: " + id + " : %s", err); return err}
 
-	err = unmarshal(bytes, &toStoreObject);
+	err = unmarshal(bytes, toStoreObject)
 
-	if err != nil {	fmt.Printf("RetrievePolicy: Cannot unmarshall object with id: " + id + " : %s", err); return err}
+	if err != nil {	fmt.Printf("RetrieveObject: Cannot unmarshall object with id: " + id + " : %s", err); return err}
 
 	return nil
 }

--- a/chaincode/src/insurance_main/dao.go
+++ b/chaincode/src/insurance_main/dao.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"github.com/hyperledger/fabric/core/util"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"encoding/json"
+	"strconv"
+	"fmt"
+)
+
+//==============================================================================================================================
+//	 Keys for obtaining the current id for the different domain object types.
+//   Ids are incremental so knowing the latest id is useful when querying for
+//   all domain objects of a certain type.
+//==============================================================================================================================
+const   CURRENT_POLICY_ID_KEY	= "currentPolicyId"
+const	CURRENT_USER_ID_KEY	= "currentUserId"
+const   CURRENT_CLAIM_ID_KEY	= "currentClaimId"
+
+const CRUD_ID_KEY = "CRUD_ID_KEY"
+
+const SAVE_FUNCTION = "save"
+const RETRIEVE_FUNCTION = "retrieve"
+
+type Dao struct {}
+
+func (t *Dao) init(stub shim.ChaincodeStubInterface, crudChaincodeId string) {
+	stub.PutState(CRUD_ID_KEY, []byte(crudChaincodeId))
+}
+
+func SavePolicy(stub shim.ChaincodeStubInterface, policy Policy) (Policy, error) {
+	if policy.Id == "" {
+		policyId := getNextPolicyId(stub)
+
+		policy.Id = policyId
+	}
+
+	bytes, err := marshall(policy)
+
+	if err != nil {fmt.Printf("\nUnable to marshall policy: %s", err); return policy, err}
+
+	err = save(stub, policy.Id, bytes)
+
+	if err != nil {fmt.Printf("Unable to save policy: %s",  err); return policy, err}
+
+	return policy, nil
+}
+
+func RetrievePolicy(stub shim.ChaincodeStubInterface, id string) (Policy, error){
+	var policy Policy
+
+	bytes, err := retrieve(stub, id)
+
+	if err != nil {	fmt.Printf("RetrievePolicy: Cannot retrieve policy: %s", err); return policy, err}
+
+	err = unmarshal(bytes, &policy);
+
+	if err != nil {	fmt.Printf("RetrievePolicy: Cannot marshall policy: %s", err); return policy, err}
+
+	return policy, nil
+}
+
+func RetrieveAllPolicies(stub shim.ChaincodeStubInterface) ([]Policy){
+	var policies []Policy
+
+	numberOfPolicies := getCurrentPolicyIdNumber(stub)
+
+	for i := 1; i <= numberOfPolicies; i++ {
+
+		policyId := POLICY_ID_PREFIX + strconv.Itoa(i)
+
+		policy, err := RetrievePolicy(stub, policyId)
+
+		if err != nil {	fmt.Printf("RetrieveAllPolicies: Error but continuing: %s", err); }
+
+		policies = append(policies, policy)
+	}
+
+	return policies
+}
+
+func retrieve(stub shim.ChaincodeStubInterface, id string) ([]byte, error) {
+	return query(stub, getCrudChaincodeId(stub), RETRIEVE_FUNCTION, []string{id})
+}
+
+func save(stub shim.ChaincodeStubInterface, id string, toSave []byte) (error){
+	return invoke(stub, getCrudChaincodeId(stub), SAVE_FUNCTION, []string{id, string(toSave)})
+}
+
+func invoke(stub shim.ChaincodeStubInterface, chaincodeId, functionName string, args []string) (error){
+	_, error := stub.InvokeChaincode(chaincodeId, createArgs(functionName, args))
+
+	return error
+}
+
+func query(stub shim.ChaincodeStubInterface, chaincodeId, functionName string, args []string) ([]byte, error){
+	return stub.QueryChaincode(chaincodeId, createArgs(functionName, args))
+}
+
+func createArgs(functionName string, args[]string) ([][]byte){
+	funcAndArgs := append([]string{functionName}, args...)
+	return util.ArrayToChaincodeArgs(funcAndArgs)
+}
+
+func marshall(toMarshall interface{}) ([]byte, error) {
+	return json.Marshal(toMarshall)
+}
+
+func unmarshal(data []byte, object interface{}) (error){
+	return json.Unmarshal(data, object)
+}
+
+func getCrudChaincodeId(stub shim.ChaincodeStubInterface) (string) {
+	bytes, _ := stub.GetState(CRUD_ID_KEY)
+	return string(bytes)
+}
+
+//==============================================================================================================================
+//	 ID Functions - The current id of both policies and claims are stored in blockchain state.
+//   This value is incremented when a new policy or claim is created.
+//   A prefix is added to the id's to differentiate between policies and claims
+//==============================================================================================================================
+func getCurrentPolicyIdNumber(stub shim.ChaincodeStubInterface) (int) {
+	return getCurrentIdNumber(stub, CURRENT_POLICY_ID_KEY);
+}
+
+func getNextPolicyId(stub shim.ChaincodeStubInterface) (string) {
+
+	return getNextId(stub, CURRENT_POLICY_ID_KEY, POLICY_ID_PREFIX);
+}
+
+func getNextUserId(stub shim.ChaincodeStubInterface) (string) {
+
+	return getNextId(stub, CURRENT_USER_ID_KEY, USER_ID_PREFIX);
+}
+
+func getCurrentClaimIdNumber(stub shim.ChaincodeStubInterface) (int) {
+	return getCurrentIdNumber(stub, CURRENT_CLAIM_ID_KEY);
+}
+
+func getNextClaimId(stub shim.ChaincodeStubInterface) (string) {
+
+	return getNextId(stub, CURRENT_CLAIM_ID_KEY, CLAIM_ID_PREFIX);
+}
+
+func getNextId(stub shim.ChaincodeStubInterface, idKey string, idPrefix string) (string) {
+
+	currentId := getCurrentIdNumber(stub, idKey)
+
+	nextIdNum := strconv.Itoa(currentId + 1)
+
+	stub.PutState(idKey, []byte(nextIdNum))
+
+	return idPrefix + nextIdNum
+}
+
+func getCurrentIdNumber(stub shim.ChaincodeStubInterface, idKey string) (int) {
+	bytes, err := stub.GetState(idKey);
+
+	if err != nil { fmt.Printf("getCurrentIdNumber Error getting id %s", err); return -1}
+
+	currentId, err := strconv.Atoi(string(bytes))
+
+	return currentId;
+}

--- a/chaincode/src/insurance_main/initData.go
+++ b/chaincode/src/insurance_main/initData.go
@@ -8,18 +8,11 @@ func InitReferenceData(stub shim.ChaincodeStubInterface) (error) {
 	SavePolicy(stub, NewPolicy("P1", "claimant1", "31/01/17", "30/01/18", 300, "BP08BRV"))
 	SavePolicy(stub, NewPolicy("P2", "claimant2", "11/01/17", "10/01/18", 250, "DZ14TYV"))
 
+	SaveVehicle(stub, NewVehicle("BP08BRV", "Ford", "Focus", "2008", 55000, "100924404"))
+	SaveVehicle(stub, NewVehicle("DZ14TYV", "Audi", "TT", "2014", 20000, "200481078"))
+
 	return nil
 }
-
-//Vehicle1 data
-var VehicleArgs1 = []string{"Ford", "Focus", "BP08BRV", "2008", "55000", "100924404"}
-var VehicleCaller1 = "claimant1"
-var VehicleCallerAffiliation1 = "group1"
-
-//Vehicle2 data
-var VehicleArgs2 = []string{"Audi", "TT", "DZ14TYV", "2014", "20000", "200481078"}
-var VehicleCaller2 = "claimant2"
-var VehicleCallerAffiliation2 = "group1"
 
 //User1 data
 var UserArgs1 = []string{"John", "Hancock", "john.hancock@outlook.com"}

--- a/chaincode/src/insurance_main/initData.go
+++ b/chaincode/src/insurance_main/initData.go
@@ -1,14 +1,15 @@
 package main
 
-//Policy1 data
-var PolicyArgs1 = []string{"31/01/17", "30/01/18", "300", "BP08BRV"}
-var PolicyCaller1 = "claimant1"
-var PolicyCallerAffiliation1 = "group1"
+import (
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
 
-//Policy2 data
-var PolicyArgs2 = []string{"11/01/17", "10/01/18", "250", "DZ14TYV"}
-var PolicyCaller2 = "claimant2"
-var PolicyCallerAffiliation2 = "group1"
+func InitReferenceData(stub shim.ChaincodeStubInterface) (error) {
+	SavePolicy(stub, NewPolicy("P1", "claimant1", "31/01/17", "30/01/18", 300, "BP08BRV"))
+	SavePolicy(stub, NewPolicy("P2", "claimant2", "11/01/17", "10/01/18", 250, "DZ14TYV"))
+
+	return nil
+}
 
 //Vehicle1 data
 var VehicleArgs1 = []string{"Ford", "Focus", "BP08BRV", "2008", "55000", "100924404"}

--- a/chaincode/src/insurance_main/initData.go
+++ b/chaincode/src/insurance_main/initData.go
@@ -5,24 +5,24 @@ import (
 )
 
 func InitReferenceData(stub shim.ChaincodeStubInterface) (error) {
-	SavePolicy(stub, NewPolicy("P1", "claimant1", "31/01/17", "30/01/18", 300, "BP08BRV"))
-	SavePolicy(stub, NewPolicy("P2", "claimant2", "11/01/17", "10/01/18", 250, "DZ14TYV"))
+	_, err := SavePolicy(stub, NewPolicy("P1", "claimant1", "31/01/17", "30/01/18", 300, "BP08BRV"))
+	if err != nil{ return err }
+	_, err = SavePolicy(stub, NewPolicy("P2", "claimant2", "11/01/17", "10/01/18", 250, "DZ14TYV"))
+	if err != nil{ return err }
 
-	SaveVehicle(stub, NewVehicle("BP08BRV", "Ford", "Focus", "2008", 55000, "100924404"))
-	SaveVehicle(stub, NewVehicle("DZ14TYV", "Audi", "TT", "2014", 20000, "200481078"))
+	_, err = SaveVehicle(stub, NewVehicle("BP08BRV", "Ford", "Focus", "2008", 55000, "100924404"))
+	if err != nil{ return err }
+	_, err = SaveVehicle(stub, NewVehicle("DZ14TYV", "Audi", "TT", "2014", 20000, "200481078"))
+	if err != nil{ return err }
 
-	return nil
+	_, err = SaveUser(stub, NewUser("U1", "John", "Hancock", "john.hancock@outlook.com", "P1"))
+	if err != nil{ return err }
+	_, err = SaveUser(stub, NewUser("U2", "Jane", "Doe", "jane.doe@outlook.com", "P2"))
+	if err != nil{ return err }
+
+	var approvedGarages ApprovedGarages
+	approvedGarages.Garages = []string{"garage1", "garage2", "garage3"}
+	_, err = SaveApprovedGarages(stub, approvedGarages)
+
+	return err
 }
-
-//User1 data
-var UserArgs1 = []string{"John", "Hancock", "john.hancock@outlook.com"}
-var UserCaller1 = "claimant1"
-var UserCallerAffiliation1 = "group1"
-
-//User2 data
-var UserArgs2 = []string{"Jane", "Doe", "jane.doe@outlook.com"}
-var UserCaller2 = "claimant2"
-var UserCallerAffiliation2 = "group1"
-
-//ApprovedGarage data
-var ApprovedGaragesData = []string{"garage1", "garage2", "garage3"}

--- a/chaincode/src/insurance_main/insurance.go
+++ b/chaincode/src/insurance_main/insurance.go
@@ -685,7 +685,7 @@ func (t *InsuranceChaincode) processConfirmPaidOut(stub shim.ChaincodeStubInterf
 func (t *InsuranceChaincode) isApprovedGarage(stub shim.ChaincodeStubInterface, garage string) bool {
 
 	approvedGarages, err := RetrieveApprovedGarages(stub)
-	if err != nil {	fmt.Printf("IS_APPROVED_GARAGE: Corrupt garages record "+string(bytes)+": %s", err); return false}
+	if err != nil {	fmt.Printf("IS_APPROVED_GARAGE: Unable to retrieve the approved garages: %s", err); return false}
 
     for _, appGarage := range approvedGarages.Garages {
 		fmt.Printf("Approved Garage: %s\n", appGarage)

--- a/chaincode/src/insurance_main/insurance.go
+++ b/chaincode/src/insurance_main/insurance.go
@@ -56,12 +56,13 @@ func main() {
 
 func (t *InsuranceChaincode) Init(stub shim.ChaincodeStubInterface, function string, args []string) ([]byte, error) {
 
-	stub.PutState(CURRENT_POLICY_ID_KEY, []byte("0"))
+	InitDao(stub, args[0])
+	InitOracleService(stub, args)
+
 	stub.PutState(CURRENT_USER_ID_KEY, []byte("0"))
 	stub.PutState(CURRENT_CLAIM_ID_KEY, []byte("0"))
 
 	t.initSetup(stub)
-	InitOracleService(stub, args)
 
 	return nil, nil
 }

--- a/chaincode/src/insurance_main/oracleService.go
+++ b/chaincode/src/insurance_main/oracleService.go
@@ -13,8 +13,8 @@ import (
 const ORACLE_HOST_KEY = "oracleHost"
 
 func InitOracleService(stub shim.ChaincodeStubInterface, args []string) {
-	if (len(args) >= 1) {
-		stub.PutState(ORACLE_HOST_KEY, []byte(args[0]))
+	if (len(args) >= 2) {
+		stub.PutState(ORACLE_HOST_KEY, []byte(args[1]))
 	} else {
 		stub.DelState(ORACLE_HOST_KEY)
 	}

--- a/chaincode/src/insurance_main/policy.go
+++ b/chaincode/src/insurance_main/policy.go
@@ -35,10 +35,9 @@ type PolicyRelations struct {
 //=================================================================================================================================
 //	 newPolicy	-	Constructs a new policy
 //=================================================================================================================================
-func NewPolicy(id string, owner string, startDate string, endDate string, excess int, vehicleReg string) (Policy) {
+func NewPolicy(owner string, startDate string, endDate string, excess int, vehicleReg string) (Policy) {
 	var policy Policy
 
-	policy.Id = id
 	policy.Type = "policy"
 
 	policy.Details.StartDate = startDate

--- a/chaincode/src/insurance_main/policy.go
+++ b/chaincode/src/insurance_main/policy.go
@@ -35,10 +35,11 @@ type PolicyRelations struct {
 //=================================================================================================================================
 //	 newPolicy	-	Constructs a new policy
 //=================================================================================================================================
-func NewPolicy(owner string, startDate string, endDate string, excess int, vehicleReg string) (Policy) {
+func NewPolicy(id string, owner string, startDate string, endDate string, excess int, vehicleReg string) (Policy) {
 	var policy Policy
 
 	policy.Type = "policy"
+	policy.Id = id
 
 	policy.Details.StartDate = startDate
 	policy.Details.EndDate = endDate

--- a/chaincode/src/insurance_main/vehicle.go
+++ b/chaincode/src/insurance_main/vehicle.go
@@ -24,10 +24,10 @@ type VehicleDetails struct {
 //=================================================================================================================================
 //	 New Vehicle	-	Constructs a new vehicle
 //=================================================================================================================================
-func NewVehicle(id string, make string, model string, registration string, year string, mileage int, styleId string) (Vehicle) {
+func NewVehicle(registration string, make string, model string, year string, mileage int, styleId string) (Vehicle) {
 	var vehicle Vehicle
 
-	vehicle.Id = id
+	vehicle.Id = registration
 	vehicle.Type = "vehicle"
 
 	vehicle.Details.Make = make

--- a/scripts/total_loss_progress_to_closed.sh
+++ b/scripts/total_loss_progress_to_closed.sh
@@ -39,7 +39,7 @@ curl -H "Content-Type: application/json" -X POST -d '{
         "function":"init",
         "args": ["insurancecrud"]
     },
-    "secureContext": "jim"
+    "secureContext": "insurer1"
   },
   "id": 1
 }' http://localhost:7050/chaincode

--- a/scripts/total_loss_progress_to_closed.sh
+++ b/scripts/total_loss_progress_to_closed.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+printf "*** Registering User bob ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{"enrollId": "garage1","enrollSecret": "123456789123"}' http://localhost:7050/registrar
+sleep 1
+curl -H "Content-Type: application/json" -X POST -d '{"enrollId": "claimant1","enrollSecret": "123456789123"}' http://localhost:7050/registrar
+sleep 1
+curl -H "Content-Type: application/json" -X POST -d '{"enrollId": "insurer1","enrollSecret": "123456789123"}' http://localhost:7050/registrar
+sleep 1
+
+printf "\n*** Deploying CRUD chaincode ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+  "jsonrpc": "2.0",
+  "method": "deploy",
+  "params": {
+    "type": 1,
+    "chaincodeID":{
+        "name": "insurancecrud"
+    },
+    "ctorMsg": {
+        "function":"init"
+    },
+    "secureContext": "insurer1"
+  },
+  "id": 1
+}' http://localhost:7050/chaincode
+sleep 3
+
+#"args": ["localhost:3000"]
+printf "\n*** Deploying main chaincode ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+  "jsonrpc": "2.0",
+  "method": "deploy",
+  "params": {
+    "type": 1,
+    "chaincodeID":{
+        "name": "insurance"
+    },
+    "ctorMsg": {
+        "function":"init",
+        "args": ["insurancecrud"]
+    },
+    "secureContext": "jim"
+  },
+  "id": 1
+}' http://localhost:7050/chaincode
+sleep 3
+
+printf "\n*** Creating policy ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "invoke",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "addPolicy",
+             "args": [
+                 "2017-02-08",
+                 "2018-02-08",
+                 "100",
+                 "DZ14TYV"
+             ]
+         },
+         "secureContext": "claimant1",
+				 "attributes": ["username","role"]
+     },
+     "id": 2
+ }' http://localhost:7050/chaincode
+sleep 3
+ 
+printf "\n*** Creating claim ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "invoke",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "createClaim",
+             "args": [
+                 "P3",
+                 "I crashed into a tree",
+                 "2017-02-10",
+                 "minor"
+             ]
+         },
+         "secureContext": "claimant1",
+				 "attributes": ["username","role"]
+     },
+     "id": 3
+ }' http://localhost:7050/chaincode
+sleep 3
+
+printf "\n*** Adding garage report ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "invoke",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "addGarageReport",
+             "args": [
+                 "C1",
+                 "15000",
+                 "false",
+                 "Half a tree sticking out of the engine",
+                 "DZ14TYV"
+             ]
+         },
+         "secureContext": "garage1",
+				 "attributes": ["username","role"]
+     },
+     "id": 3
+ }' http://localhost:7050/chaincode
+sleep 3
+
+printf "\n*** Agreeing to valuation ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "invoke",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "agreePayoutAmount",
+             "args": [
+                 "C1",
+                 "true"
+             ]
+         },
+         "secureContext": "claimant1",
+				 "attributes": ["username","role"]
+     },
+     "id": 3
+ }' http://localhost:7050/chaincode
+sleep 3
+
+printf "\n*** Confirming Paid ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "invoke",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "confirmPaidOut",
+             "args": [
+                 "C1"
+             ]
+         },
+         "secureContext": "insurer1",
+				 "attributes": ["username","role"]
+     },
+     "id": 3
+ }' http://localhost:7050/chaincode
+sleep 3
+
+printf "\n*** Close Claim ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "invoke",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "closeClaim",
+             "args": [
+                 "C1"
+             ]
+         },
+         "secureContext": "insurer1",
+				 "attributes": ["username","role"]
+     },
+     "id": 3
+ }' http://localhost:7050/chaincode
+sleep 3
+ 
+printf "\n*** Retrieving policies ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "query",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "retrieveAllPolicies"
+         },
+         "secureContext": "claimant1",
+				 "attributes": ["username","role"]
+     },
+     "id": 4
+ }' http://localhost:7050/chaincode
+ 
+printf "\n*** Retrieving claims ***\n"
+curl -H "Content-Type: application/json" -X POST -d '{
+     "jsonrpc": "2.0",
+     "method": "query",
+     "params": {
+         "type": 1,
+         "chaincodeID": {
+             "name": "insurance"
+         },
+         "ctorMsg": {
+             "function": "retrieveAllClaims"
+         },
+         "secureContext": "claimant1",
+				 "attributes": ["username","role"]
+     },
+     "id": 3
+ }' http://localhost:7050/chaincode
+
+
+


### PR DESCRIPTION
Seperated the setting and getting of state into a seperate chaincode contract so that the logic can be modified without having to lose the state.  Some refactoring of the agree value and confirm payment functionality.